### PR TITLE
Return 'false' if the interval cannot be determined.

### DIFF
--- a/getdash.app.js
+++ b/getdash.app.js
@@ -107,7 +107,7 @@ define([
     alias: '',
     tags: [],  // [tagProto]
     select: [],  // [selectProto]
-    interval: '1m',
+    interval: false,
     query: '',
     groupBy: [
       {
@@ -716,7 +716,7 @@ define([
   var getInterval = function getInterval (time) {
     var rTime = parseTime(time);
     if (!rTime)
-      return '1m';
+      return false;
 
     var timeM = 0;
     if (rTime[2] === 'm')


### PR DESCRIPTION
Then the grafana will itself define a good value for the interval. If returning '1m', loading graphs for a long timespan (i.e. 1 month) takes very long, as a lot of data is reqeusted and returned by influxdb.