### PR TITLE
Add initial implementation of GET refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Javascript dashboard auto-generation script to mimic comfortable Munin behaviour in Grafana. Main project goal is to be able to see all the stats for the added machine in one dashboard (to have possibility to add auto-generated URL to the existing monitoring system alarm notification for faster incident investigation). Project is written and tested with CollectD->InfluxDB+(input_plugins.collectd) as a system stats collector but with minor configuration changes should be collector independent.
 
-:white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.8.8**  
-:white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.11.1**  
-:white_check_mark: Tested for **Grafana 3.0.4** and **InfluxDB v0.13.0**  
+:white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.8.8**
+:white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.11.1**
+:white_check_mark: Tested for **Grafana 3.0.4** and **InfluxDB v0.13.0**
 
 ## Demonstration
 ![](https://media.giphy.com/media/3oEdvcYi3a3KVvtuHS/giphy.gif)
@@ -42,6 +42,8 @@ http://grafanaIP/dashboard/script/getdash.js?host=hostname&metric=disk&instance=
 http://grafanaIP/dashboard/script/getdash.js?host=hostname&metric=disk&instance=sd*
 http://grafanaIP/dashboard/script/getdash.js?host=hostname&metric=disk&instance=sda1,sdb1
 http://grafanaIP/dashboard/script/getdash.js?host=hostname&metric=disk&instance=sda[1-3]
+http://grafanaIP/dashboard/script/getdash.js?host=hostname&refresh=5s
+http://grafanaIP/dashboard/script/getdash.js?host=hostname&metric=disk&instance=sda1&refresh=1m
 ```
 
 ## Features
@@ -82,9 +84,17 @@ http://grafanaIP/dashboard/script/getdash.js?host=hostname&metric=disk&instance=
 * database
 
 #### Supported time format
+For time :
+
 ```
 /(\d+)(m|h|d)/
 ```
+
+For refresh :
+```
+/(\d+)(s|m|h|d)/
+```
+
 <sub>_Grouping by time is automatically adjusted._</sub>
 
 
@@ -237,4 +247,3 @@ http://grafanaIP/render/dashboard-solo/script/getdash.js?host=hostname&metric=cp
 
 #### Adding getdash to grafana dashboard list
 [Issue #54](https://github.com/anryko/grafana-influx-dashboard/issues/54)
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Javascript dashboard auto-generation script to mimic comfortable Munin behaviour
 
 :white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.8.8**
 :white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.11.1**
-:white_check_mark: Tested for **Grafana 3.0.4** and **InfluxDB v0.13.0**
+:white_check_mark: Tested for **Grafana 3.0.4** and **InfluxDB v0.13.0** 
 
 ## Demonstration
 ![](https://media.giphy.com/media/3oEdvcYi3a3KVvtuHS/giphy.gif)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 Javascript dashboard auto-generation script to mimic comfortable Munin behaviour in Grafana. Main project goal is to be able to see all the stats for the added machine in one dashboard (to have possibility to add auto-generated URL to the existing monitoring system alarm notification for faster incident investigation). Project is written and tested with CollectD->InfluxDB+(input_plugins.collectd) as a system stats collector but with minor configuration changes should be collector independent.
 
 :white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.8.8**
-
 :white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.11.1**
-
 :white_check_mark: Tested for **Grafana 3.0.4** and **InfluxDB v0.13.0**
 
 ## Demonstration

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 Javascript dashboard auto-generation script to mimic comfortable Munin behaviour in Grafana. Main project goal is to be able to see all the stats for the added machine in one dashboard (to have possibility to add auto-generated URL to the existing monitoring system alarm notification for faster incident investigation). Project is written and tested with CollectD->InfluxDB+(input_plugins.collectd) as a system stats collector but with minor configuration changes should be collector independent.
 
 :white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.8.8**
+
 :white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.11.1**
+
 :white_check_mark: Tested for **Grafana 3.0.4** and **InfluxDB v0.13.0**
 
 ## Demonstration

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Javascript dashboard auto-generation script to mimic comfortable Munin behaviour in Grafana. Main project goal is to be able to see all the stats for the added machine in one dashboard (to have possibility to add auto-generated URL to the existing monitoring system alarm notification for faster incident investigation). Project is written and tested with CollectD->InfluxDB+(input_plugins.collectd) as a system stats collector but with minor configuration changes should be collector independent.
 
-:white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.8.8**
-:white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.11.1**
-:white_check_mark: Tested for **Grafana 3.0.4** and **InfluxDB v0.13.0** 
+:white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.8.8**  
+:white_check_mark: Tested for **Grafana 2.6.0** and **InfluxDB v0.11.1**  
+:white_check_mark: Tested for **Grafana 3.0.4** and **InfluxDB v0.13.0**  
 
 ## Demonstration
 ![](https://media.giphy.com/media/3oEdvcYi3a3KVvtuHS/giphy.gif)

--- a/getdash.app.js
+++ b/getdash.app.js
@@ -696,6 +696,22 @@ var getDashApp = function getDashApp (datasourcesAll, getdashConf) {
   };
 
 
+  // parseRefresh :: timeStr -> [timeStr]
+  var parseRefresh = function parseRefresh (refresh) {
+    var regexpRefresh = /(\d+)(s|m|h|d)/;
+    return regexpRefresh.exec(refresh);
+  };
+
+
+  // getDashboardRefresh :: timeStr -> dashboardTimeObj
+  var getDashboardRefresh = function getDashboardRefresh (refresh) {
+    if (!refresh || !parseRefresh(refresh))
+      return '';
+
+    return refresh;
+  };
+
+
   // getMetricArr :: pluginsObj, displayMetricStr -> [metricStr]
   var getMetricArr = _.curry(function getMetricArr (plugins, displayMetric) {
     if (!displayMetric)
@@ -927,7 +943,8 @@ var getDashApp = function getDashApp (datasourcesAll, getdashConf) {
   var getDashboard = _.curry(function getDashboard (datasources, plugins, dashConf, callback) {
     var dashboard = {
       title: dashConf.title,
-      time: getDashboardTime(dashConf.time)
+      time: getDashboardTime(dashConf.time),
+      refresh: getDashboardRefresh(dashConf.refresh)
     };
 
     if (!dashConf.host && !dashConf.metric) {

--- a/getdash.js
+++ b/getdash.js
@@ -46,6 +46,7 @@ return function scriptedDashboard (callback) {
       metric: (_.isUndefined(ARGS.metric)) ? '' : sanitize(ARGS.metric),
       instance: (_.isUndefined(ARGS.instance)) ? undefined : ARGS.instance,
       time: (_.isUndefined(ARGS.time)) ? undefined : sanitize(ARGS.time),
+      refresh: (_.isUndefined(ARGS.refresh)) ? undefined : sanitize(ARGS.refresh),
       span: (_.isUndefined(ARGS.span)) ? 12 : sanitize(ARGS.span),
       title: 'Dashboard for ' + displayHost,
       // Series used to get the list of all hosts


### PR DESCRIPTION
Hi @anryko ,

I set up the opportunity with the tag "refresh" to choose the interval time to refresh the dashboard.

Example:
http://grafanaIP/dashboard/script/getdash.js?host=hostname&refresh=5s

The way to do can probably be improved but it works.

Thank you.

Cordially.