### PR TITLE
Add plugin configuration for MongooseIM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM grafana/grafana:4.0.2
+
+ADD getdash.js /getdash.js
+ADD getdash.app.js /getdash.app.js
+ADD getdash.conf.js /getdash.conf.js
+
+ADD install.sh /install.sh
+RUN chmod +x /install.sh
+
+RUN ./install.sh /usr/share/grafana

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:4.0.2
+FROM grafana/grafana:4.1.1
 
 ADD getdash.js /getdash.js
 ADD getdash.app.js /getdash.app.js

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ http://grafanaIP/dashboard/script/getdash.js?metric=docker&time=30m&legend=align
 * [mysql](https://collectd.org/wiki/index.php/Plugin:MySQL)
 * [tcpconns](https://collectd.org/wiki/index.php/Plugin:TCPConns)
 * [kafka](https://collectd.org/wiki/index.php/Plugin:GenericJMX)
+* [mongooseim](http://mongooseim.readthedocs.io/en/1.6.2/developers-guide/REST-interface-to-metrics/)
 * [docker](https://github.com/signalfx/docker-collectd-plugin)
 * [couchbase](https://github.com/anryko/collectd-couchbase)
 

--- a/examples/collectd.conf.d/mongooseim.conf
+++ b/examples/collectd.conf.d/mongooseim.conf
@@ -1,0 +1,31 @@
+LoadPlugin curl_json
+LoadPlugin match_regex
+LoadPlugin target_set
+
+<Plugin "curl_json">
+    <URL "http://localhost:5280/api/metrics/all">
+        Instance "mongooseim"
+        <Key "metrics/sessionCount">
+            Type "absolute"
+        </Key>
+        <Key "metrics/*/count">
+            Type "absolute"
+        </Key>
+        <Key "metrics/*/one">
+            Type "absolute"
+        </Key>
+    </URL>
+</Plugin>
+
+PreCacheChain "PreCache"
+<Chain "PreCache">
+    <Rule "RenameToMongooseIM">
+        <Match "regex">
+            Plugin "^curl_json$"
+            PluginInstance "^mongooseim$"
+        </Match>
+        <Target "set">
+            Plugin "mongooseim"
+        </Target>
+    </Rule>
+</Chain>

--- a/getdash.conf.js
+++ b/getdash.conf.js
@@ -3087,6 +3087,164 @@ var getDashConf = function getDashConf () {
   };
 
 
+  // collectd curl_json plugin configuration for mongooseim
+  plugins.curl_json = new Plugin();
+  plugins.curl_json.config.multi = true;
+  plugins.curl_json.config.regexp = /^mongooseim$/;
+
+  plugins.curl_json.mongooseimSessionsAndErrors = {
+    'graph': {
+      'sessionCount': {
+        'color': '#1F78C1',
+        'alias': '@instance.session_count@'
+      },
+      'xmppErrorTotal-one': {
+        'color': '#EF843C',
+        'alias': '@instance.error_count@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM Sessions and Errors',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.curl_json.mongooseimSessions = {
+    'graph': {
+      'sessionAuthAnonymous-count': {
+        'color': '#1F78C1',
+        'alias': '@instance.auth_anonymous_count@'
+      },
+      'sessionAuthFails-count': {
+        'color': '#EF843C',
+        'alias': '@instance.auth_fails_count@'
+      },
+      'sessionLogouts-count': {
+        'color': '#CCA300',
+        'alias': '@instance.logouts_count@'
+      },
+      'sessionSuccessfulLogins-count': {
+        'color': '#629E51',
+        'alias': '@instance.successful_logins_count@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM Sessions',
+      'lines': false,
+      'bars': true,
+      'stack': true,
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.curl_json.mongooseimErrors = {
+    'graph': {
+      'xmppErrorBadRequest-count': {
+        'color': '#1F78C1',
+        'alias': '@instance.error_bad_equest_count@'
+      },
+      'xmppErrorIq-one': {
+        'color': '#EF843C',
+        'alias': '@instance.error_iq_count@'
+      },
+      'xmppErrorMessage-count': {
+        'color': '#CCA300',
+        'alias': '@instance.error_message_count@'
+      },
+      'xmppErrorPresence-count': {
+        'color': '#629E51',
+        'alias': '@instance.error_presence_count@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM Errors',
+      'lines': false,
+      'bars': true,
+      'stack': true,
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.curl_json.mongooseimMessages = {
+    'graph': {
+      'xmppMessageReceived-one': {
+        'color': '#508642',
+        'alias': '@instance.message_received@'
+      },
+      'xmppMessageSent-one': {
+        'color': '#447EBC',
+        'math': '* -1',
+        'alias': '@instance.message_sent@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM Messages',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.curl_json.mongooseimIq = {
+    'graph': {
+      'xmppIqReceived-one': {
+        'color': '#508642',
+        'alias': '@instance.iq_received@'
+      },
+      'xmppIqSent-one': {
+        'color': '#447EBC',
+        'math': '* -1',
+        'alias': '@instance.iq_sent@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM IQ',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.curl_json.mongooseimPresence = {
+    'graph': {
+      'xmppPresenceReceived-one': {
+        'color': '#508642',
+        'alias': '@instance.presence_received@'
+      },
+      'xmppPresenceSent-one': {
+        'color': '#447EBC',
+        'math': '* -1',
+        'alias': '@instance.presence_sent@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM Presence',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.curl_json.mongooseimStanzas = {
+    'graph': {
+      'xmppStanzaReceived-one': {
+        'color': '#508642',
+        'alias': '@instance.stanza_received@'
+      },
+      'xmppStanzaSent-one': {
+        'color': '#447EBC',
+        'math': '* -1',
+        'alias': '@instance.stanza_sent@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM Stanzas',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+
   // collectd docker plugin configuration: https://github.com/lebauce/docker-collectd-plugin
   plugins.docker = new Plugin();
 

--- a/getdash.conf.js
+++ b/getdash.conf.js
@@ -3090,48 +3090,19 @@ var getDashConf = function getDashConf () {
   // collectd curl_json plugin configuration for mongooseim
   plugins.mongooseim = new Plugin();
 
-  plugins.mongooseim.sessionsAndErrors = {
+  plugins.mongooseim.overview = {
     'graph': {
       'sessionCount': {
         'color': '#1F78C1',
-        'alias': '@instance.session_count@'
+        'alias': '@instance.sessions_count@'
       },
       'xmppErrorTotal-one': {
         'color': '#EF843C',
-        'alias': '@instance.error_count@'
+        'alias': '@instance.errors_count@'
       }
     },
     'panel': {
       'title': 'MongooseIM Sessions and Errors',
-      'tooltip': { 'sort': 2 },
-      'yaxes': [ { 'format': 'short' }, {} ]
-    }
-  };
-
-  plugins.mongooseim.sessions = {
-    'graph': {
-      'sessionAuthAnonymous-one': {
-        'color': '#1F78C1',
-        'alias': '@instance.auth_anonymous_count@'
-      },
-      'sessionAuthFails-one': {
-        'color': '#EF843C',
-        'alias': '@instance.auth_fails_count@'
-      },
-      'sessionLogouts-one': {
-        'color': '#CCA300',
-        'alias': '@instance.logouts_count@'
-      },
-      'sessionSuccessfulLogins-one': {
-        'color': '#629E51',
-        'alias': '@instance.successful_logins_count@'
-      }
-    },
-    'panel': {
-      'title': 'MongooseIM Sessions',
-      'lines': false,
-      'bars': true,
-      'stack': true,
       'tooltip': { 'sort': 2 },
       'yaxes': [ { 'format': 'short' }, {} ]
     }
@@ -3166,6 +3137,53 @@ var getDashConf = function getDashConf () {
     }
   };
 
+  plugins.mongooseim.auth = {
+    'graph': {
+      'sessionAuthAnonymous-one': {
+        'color': '#1F78C1',
+        'alias': '@instance.auth_anonymous_count@'
+      },
+      'sessionAuthFails-one': {
+        'color': '#EF843C',
+        'alias': '@instance.auth_fails_count@'
+      },
+      'sessionLogouts-one': {
+        'color': '#CCA300',
+        'alias': '@instance.logouts_count@'
+      },
+      'sessionSuccessfulLogins-one': {
+        'color': '#629E51',
+        'alias': '@instance.successful_logins_count@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM Authentication',
+      'lines': false,
+      'bars': true,
+      'stack': true,
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.mongooseim.registrations = {
+    'graph': {
+      'modRegisterCount-one': {
+        'color': '#1F78C1',
+        'alias': '@instance.register_count@'
+      },
+      'modUnregisterCount-one': {
+        'color': '#EF843C',
+        'alias': '@instance.unregister_count@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM Registrations',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
   plugins.mongooseim.messages = {
     'graph': {
       'xmppMessageReceived-one': {
@@ -3176,6 +3194,10 @@ var getDashConf = function getDashConf () {
         'color': '#447EBC',
         'math': '* -1',
         'alias': '@instance.message_sent@'
+      },
+      'xmppMessageBounced-one': {
+        'color': '#EAB839',
+        'alias': '@instance.message_bounced@'
       }
     },
     'panel': {
@@ -3195,6 +3217,10 @@ var getDashConf = function getDashConf () {
         'color': '#447EBC',
         'math': '* -1',
         'alias': '@instance.iq_sent@'
+      },
+      'xmppIqTimeouts-one': {
+        'color': '#EAB839',
+        'alias': '@instance.iq_timeouts@'
       }
     },
     'panel': {
@@ -3233,10 +3259,157 @@ var getDashConf = function getDashConf () {
         'color': '#447EBC',
         'math': '* -1',
         'alias': '@instance.stanza_sent@'
+      },
+      'xmppStanzaDropped-one': {
+        'color': '#EAB839',
+        'alias': '@instance.stanza_dropped@'
       }
     },
     'panel': {
       'title': 'MongooseIM Stanzas',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.mongooseim.roster = {
+    'graph': {
+      'modRosterGets-one': {
+        'color': '#508642',
+        'alias': '@instance.roster_gets@'
+      },
+      'modRosterSets-one': {
+        'color': '#447EBC',
+        'math': '* -1',
+        'alias': '@instance.roster_sets@'
+      },
+      'modRosterPush-one': {
+        'color': '#EAB839',
+        'alias': '@instance.roster_push@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM Roster',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.mongooseim.mucMam = {
+    'graph': {
+      'modMucMamLookups-one': {
+        'color': '#1F78C1',
+        'alias': '@instance.muc_mam_lookups@'
+      },
+      'modMucMamForwarded-one': {
+        'color': '#EF843C',
+        'alias': '@instance.muc_mam_forwarded@'
+      },
+      'modMucMamArchived-one': {
+        'color': '#CCA300',
+        'alias': '@instance.muc_mam_archived@'
+      },
+      'modMucMamArchiveRemoved-one': {
+        'color': '#629E51',
+        'alias': '@instance.muc_mam_archive_removed@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM MUC MAM',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.mongooseim.mucMamDetails = {
+    'graph': {
+      'modMucMamPrefsGets-one': {
+        'color': '#1F78C1',
+        'alias': '@instance.muc_mam_prefs_gets@'
+      },
+      'modMucMamPrefsSets-one': {
+        'color': '#EF843C',
+        'alias': '@instance.muc_mam_prefs_sets@'
+      },
+      'modMucMamSinglePurges-one': {
+        'color': '#CCA300',
+        'alias': '@instance.muc_mam_single_purges@'
+      },
+      'modMucMamMultiplePurges-one': {
+        'color': '#629E51',
+        'alias': '@instance.muc_mam_multiple_purges@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM MUC MAM Details',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.mongooseim.mam = {
+    'graph': {
+      'modMamLookups-one': {
+        'color': '#EAB839',
+        'alias': '@instance.mam_lookups@'
+      },
+      'modMamForwarded-one': {
+        'color': '#508642',
+        'alias': '@instance.mam_forwarded@'
+      },
+      'modMamArchived-one': {
+        'color': '#303030',
+        'alias': '@instance.mam_archived@'
+      },
+      'modMamArchiveRemoved-one': {
+        'color': '#890F02',
+        'alias': '@instance.mam_archive_removed@'
+      },
+      'modMamFlushed-one': {
+        'color': '#E24D42',
+        'alias': '@instance.mam_flushed@'
+      },
+      'modMamDropped-one': {
+        'color': '#9400D3',
+        'alias': '@instance.mam_dropped@'
+      },
+      'modMamDropped2-one': {
+        'color': '#E9967A',
+        'alias': '@instance.mam_dropped_2@'
+      },
+      'modMamDroppedIQ-one': {
+        'color': '#1E90FF',
+        'alias': '@instance.mam_dropped_iq@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM MAM',
+      'tooltip': { 'sort': 2 },
+      'yaxes': [ { 'format': 'short' }, {} ]
+    }
+  };
+
+  plugins.mongooseim.mamDetails = {
+    'graph': {
+      'modMamPrefsGets-one': {
+        'color': '#1F78C1',
+        'alias': '@instance.mam_prefs_gets@'
+      },
+      'modMamPrefsSets-one': {
+        'color': '#EF843C',
+        'alias': '@instance.mam_prefs_sets@'
+      },
+      'modMamSinglePurges-one': {
+        'color': '#CCA300',
+        'alias': '@instance.mam_single_purges@'
+      },
+      'modMamMultiplePurges-one': {
+        'color': '#629E51',
+        'alias': '@instance.mam_multiple_purges@'
+      }
+    },
+    'panel': {
+      'title': 'MongooseIM MAM Details',
       'tooltip': { 'sort': 2 },
       'yaxes': [ { 'format': 'short' }, {} ]
     }

--- a/getdash.conf.js
+++ b/getdash.conf.js
@@ -3088,11 +3088,9 @@ var getDashConf = function getDashConf () {
 
 
   // collectd curl_json plugin configuration for mongooseim
-  plugins.curl_json = new Plugin();
-  plugins.curl_json.config.multi = true;
-  plugins.curl_json.config.regexp = /^mongooseim$/;
+  plugins.mongooseim = new Plugin();
 
-  plugins.curl_json.mongooseimSessionsAndErrors = {
+  plugins.mongooseim.sessionsAndErrors = {
     'graph': {
       'sessionCount': {
         'color': '#1F78C1',
@@ -3110,21 +3108,21 @@ var getDashConf = function getDashConf () {
     }
   };
 
-  plugins.curl_json.mongooseimSessions = {
+  plugins.mongooseim.sessions = {
     'graph': {
-      'sessionAuthAnonymous-count': {
+      'sessionAuthAnonymous-one': {
         'color': '#1F78C1',
         'alias': '@instance.auth_anonymous_count@'
       },
-      'sessionAuthFails-count': {
+      'sessionAuthFails-one': {
         'color': '#EF843C',
         'alias': '@instance.auth_fails_count@'
       },
-      'sessionLogouts-count': {
+      'sessionLogouts-one': {
         'color': '#CCA300',
         'alias': '@instance.logouts_count@'
       },
-      'sessionSuccessfulLogins-count': {
+      'sessionSuccessfulLogins-one': {
         'color': '#629E51',
         'alias': '@instance.successful_logins_count@'
       }
@@ -3139,9 +3137,9 @@ var getDashConf = function getDashConf () {
     }
   };
 
-  plugins.curl_json.mongooseimErrors = {
+  plugins.mongooseim.errors = {
     'graph': {
-      'xmppErrorBadRequest-count': {
+      'xmppErrorBadRequest-one': {
         'color': '#1F78C1',
         'alias': '@instance.error_bad_equest_count@'
       },
@@ -3149,11 +3147,11 @@ var getDashConf = function getDashConf () {
         'color': '#EF843C',
         'alias': '@instance.error_iq_count@'
       },
-      'xmppErrorMessage-count': {
+      'xmppErrorMessage-one': {
         'color': '#CCA300',
         'alias': '@instance.error_message_count@'
       },
-      'xmppErrorPresence-count': {
+      'xmppErrorPresence-one': {
         'color': '#629E51',
         'alias': '@instance.error_presence_count@'
       }
@@ -3168,7 +3166,7 @@ var getDashConf = function getDashConf () {
     }
   };
 
-  plugins.curl_json.mongooseimMessages = {
+  plugins.mongooseim.messages = {
     'graph': {
       'xmppMessageReceived-one': {
         'color': '#508642',
@@ -3187,7 +3185,7 @@ var getDashConf = function getDashConf () {
     }
   };
 
-  plugins.curl_json.mongooseimIq = {
+  plugins.mongooseim.iq = {
     'graph': {
       'xmppIqReceived-one': {
         'color': '#508642',
@@ -3206,7 +3204,7 @@ var getDashConf = function getDashConf () {
     }
   };
 
-  plugins.curl_json.mongooseimPresence = {
+  plugins.mongooseim.presence = {
     'graph': {
       'xmppPresenceReceived-one': {
         'color': '#508642',
@@ -3225,7 +3223,7 @@ var getDashConf = function getDashConf () {
     }
   };
 
-  plugins.curl_json.mongooseimStanzas = {
+  plugins.mongooseim.stanzas = {
     'graph': {
       'xmppStanzaReceived-one': {
         'color': '#508642',


### PR DESCRIPTION
Hi @anryko I'm adding support for [MongooseIM metrics](https://mongooseim.readthedocs.io/en/latest/developers-guide/REST-interface-to-metrics/).

MongooseIM metrics can be grabbed by CollectD thanks to this configuration snippet:

```
LoadPlugin curl_json
<Plugin "curl_json">
          <URL "http://<MONGOOSEIM_IP>:5280/api/metrics/all">
              Instance "mongooseim"
              <Key "metrics/sessionCount">
                  Type "absolute"
              </Key>
              <Key "metrics/*/count">
                  Type "absolute"
              </Key>
              <Key "metrics/*/one">
                  Type "absolute"
              </Key>
          </URL>
</Plugin>
```

The dashboard I added already works, but I would suggest a little change in your code. Check my comments 😉 .

Thank you for this great tool!